### PR TITLE
Add room/transition name translation to spoiler/helper/tracker logs.

### DIFF
--- a/RandomizerMod3.0/RandoLogger.cs
+++ b/RandomizerMod3.0/RandoLogger.cs
@@ -126,12 +126,12 @@ namespace RandomizerMod
 
                 MakeHelperLists();
 
-                AddToLog($"Current scene: {GameManager.instance.sceneName}");
+                AddToLog($"Current scene: {Translator.TranslateSceneName(GameManager.instance.sceneName)}");
                 if (RandomizerMod.Instance.Settings.RandomizeTransitions)
                 {
                     if (!string.IsNullOrEmpty(RandomizerMod.Instance.LastRandomizedEntrance) && !string.IsNullOrEmpty(RandomizerMod.Instance.LastRandomizedExit))
                     {
-                        AddToLog($"Last randomized transition: {{{RandomizerMod.Instance.LastRandomizedEntrance}}}-->{{{RandomizerMod.Instance.LastRandomizedExit}}}");
+                        AddToLog($"Last randomized transition: {{{Translator.TranslateTransitionName(RandomizerMod.Instance.LastRandomizedEntrance)}}}-->{{{Translator.TranslateTransitionName(RandomizerMod.Instance.LastRandomizedExit)}}}");
                     }
                     else
                     {
@@ -230,10 +230,10 @@ namespace RandomizerMod
 
                     foreach (var room in SceneSortedTransitions)
                     {
-                        AddToLog(Environment.NewLine + room.Key.Replace('_', ' '));
+                        AddToLog(Environment.NewLine + Translator.TranslateSceneName(room.Key).Replace('_', ' '));
                         foreach (string transition in room.Value)
                         {
-                            AddToLog(" - " + transition);
+                            AddToLog(" - " + Translator.TranslateTransitionName(transition));
                         }
                     }
                 }
@@ -344,12 +344,12 @@ namespace RandomizerMod
             {
                 string area1 = LogicManager.GetTransitionDef(entrance).areaName.Replace('_', ' ');
                 string area2 = LogicManager.GetTransitionDef(exit).areaName.Replace('_', ' ');
-                message = $"TRANSITION --- {{{entrance}}}-->{{{exit}}}" +
+                message = $"TRANSITION --- {{{Translator.TranslateTransitionName(entrance)}}}-->{{{Translator.TranslateTransitionName(exit)}}}" +
                     $"\n                ({area1} to {area2})";
             }
             else if (RandomizerMod.Instance.Settings.RandomizeRooms)
             {
-                message = $"TRANSITION --- {{{entrance}}}-->{{{exit}}}";
+                message = $"TRANSITION --- {{{Translator.TranslateTransitionName(entrance)}}}-->{{{Translator.TranslateTransitionName(exit)}}}";
             }
 
             LogTracker(message);
@@ -519,7 +519,7 @@ namespace RandomizerMod
                     foreach ((string, string) pair in transitionPlacements)
                     {
                         string room = LogicManager.GetTransitionDef(pair.Item1).sceneName;
-                        roomTransitions[room].Add(pair.Item1 + " --> " + pair.Item2);
+                        roomTransitions[room].Add(Translator.TranslateTransitionName(pair.Item1) + " --> " + Translator.TranslateTransitionName(pair.Item2));
                     }
 
                     AddToLog(Environment.NewLine + "TRANSITIONS");

--- a/RandomizerMod3.0/RandomizerMod.cs
+++ b/RandomizerMod3.0/RandomizerMod.cs
@@ -106,6 +106,8 @@ namespace RandomizerMod
 
             _logicParseThread.Join(); // new update -- logic manager is needed to supply start locations to menu
             MenuChanger.EditUI();
+
+            Translator.Initialize(); // Generate translation
         }
 
         public override List<(string, string)> GetPreloadNames()

--- a/RandomizerMod3.0/RandomizerMod3.0.csproj
+++ b/RandomizerMod3.0/RandomizerMod3.0.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Randomization\Randomizer.cs" />
     <Compile Include="RestrictionManager.cs" />
     <Compile Include="SaveSettings.cs" />
+    <Compile Include="Translator.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Prompts\Dash.png" />

--- a/RandomizerMod3.0/Translator.cs
+++ b/RandomizerMod3.0/Translator.cs
@@ -12,7 +12,7 @@ namespace RandomizerMod
         private static Dictionary<string, string> RevertDict = new Dictionary<string, string>();
         private static XmlDocument xml;
         private static bool DictActive;
-        private static bool ReverseDictExists;
+        private const bool ReverseDictExists = false; // Change if you wish to reverse translation in your application.
 
         /// <summary>
         /// Creates dictionary/ies for translation from file in saves folder.
@@ -20,8 +20,6 @@ namespace RandomizerMod
         /// </summary>
         public static void Initialize()
         {
-            ReverseDictExists = false; // Change if you wish to reverse translation.
-
             DictActive = LoadXML();
             if (DictActive)
             {
@@ -37,11 +35,12 @@ namespace RandomizerMod
         {
             if (!File.Exists(Path.Combine(Application.persistentDataPath, "TranslatorDictionary.xml")))
             {
-                Modding.Logger.Log("XML not found. Please place TranslatorDictionary.xml into your saves folder.");
+                LogHelper.Log("XML not found. Please place TranslatorDictionary.xml into your saves folder.");
                 return false;
             }
             xml = new XmlDocument();
             xml.Load(Path.Combine(Application.persistentDataPath, "TranslatorDictionary.xml"));
+            LogHelper.Log("Translation XML loaded.");
             return true;
         }
 

--- a/RandomizerMod3.0/Translator.cs
+++ b/RandomizerMod3.0/Translator.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using System.IO;
+using System.Xml;
+
+namespace RandomizerMod
+{
+    class Translator
+    {
+        // Dictionaries for translation.
+        private static Dictionary<string, string> TranslateDict = new Dictionary<string, string>();
+        private static Dictionary<string, string> RevertDict = new Dictionary<string, string>();
+        private static XmlDocument xml;
+        private static bool DictActive;
+        private static bool ReverseDictExists;
+
+        /// <summary>
+        /// Creates dictionary/ies for translation from file in saves folder.
+        /// If file does not exist then dictionaries are not generated, and all routines default to returning their input parameter.
+        /// </summary>
+        public static void Initialize()
+        {
+            ReverseDictExists = false; // Change if you wish to reverse translation.
+
+            DictActive = LoadXML();
+            if (DictActive)
+            {
+                CreateDicts(ReverseDictExists);
+            }
+        }
+
+        /// <summary>
+        /// Opens the dictionary xml file located in the saves folder.
+        /// </summary>
+        /// <returns>true if file is located, false if file is not located.</returns>
+        public static bool LoadXML()
+        {
+            if (!File.Exists(Path.Combine(Application.persistentDataPath, "TranslatorDictionary.xml")))
+            {
+                Modding.Logger.Log("XML not found. Please place TranslatorDictionary.xml into your saves folder.");
+                return false;
+            }
+            xml = new XmlDocument();
+            xml.Load(Path.Combine(Application.persistentDataPath, "TranslatorDictionary.xml"));
+            return true;
+        }
+
+        /// <summary>
+        /// Creates the dictionaries used for translation.
+        /// </summary>
+        /// <param name="CreateInvertedDict">Whether to create an inverse dictionary for detranslation. Only set to true if your project requires it.</param>
+        public static void CreateDicts(bool CreateInvertedDict)
+        {
+            foreach (XmlNode node in xml.DocumentElement.ChildNodes) // Iterate through each <entry> tag in dictionary.
+            {
+                TranslateDict.Add(node.SelectSingleNode("oldName").InnerText, node.SelectSingleNode("newName").InnerText);
+                if (CreateInvertedDict == true)
+                {
+                    RevertDict.Add(node.SelectSingleNode("newName").InnerText, node.SelectSingleNode("oldName").InnerText);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Translates scene name to a more descriptive room name.
+        /// </summary>
+        /// <param name="oldName">Name of scene</param>
+        /// <returns>A more descriptive room name if it exists in the dictionary, else oldName.</returns>
+        public static string TranslateSceneName(string oldName)
+        {
+            string newName;
+            if (TranslateDict.TryGetValue(oldName, out newName))
+            {
+                return newName;
+            }
+            return oldName;
+        }
+
+        /// <summary>
+        /// Translates a Randomizer 3 transition name to a more descriptive name.
+        /// </summary>
+        /// <param name="oldName">Name of transition</param>
+        /// <returns>More descriptive transition name if it exists in dictionary, else oldName.</returns>
+        public static string TranslateTransitionName(string oldName)
+        {
+            if (!DictActive) { return oldName; }
+            string[] transitionArray = oldName.Split('[', ']');
+            return TranslateSceneName(transitionArray[0]) + '[' + transitionArray[1] + ']';
+        }
+
+        /// <summary>
+        /// Reverses translation of a room name if ReverseDictExists was set to true.
+        /// </summary>
+        /// <param name="oldName">Translated room name.</param>
+        /// <returns>Original scene name.</returns>
+        public static string ReverseSceneTranslation(string oldName)
+        {
+            if (!ReverseDictExists || !DictActive) { return oldName; }
+
+            string newName;
+            if (TranslateDict.TryGetValue(oldName, out newName))
+            {
+                return newName;
+            }
+            return oldName;
+        }
+
+        /// <summary>
+        /// Reverses translation of a transition name if ReverseDictExists was set to true.
+        /// </summary>
+        /// <param name="oldName">Translated transition name.</param>
+        /// <returns>Original transition name.</returns>
+        public static string ReverseTransitionTranslation(string oldName)
+        {
+            if (!DictActive || !ReverseDictExists) { return oldName; }
+            string[] transitionArray = oldName.Split('[', ']');
+            return TranslateSceneName(transitionArray[0]) + '[' + transitionArray[1] + ']';
+        }
+    }
+}


### PR DESCRIPTION
Translates room names according to <saves directory>/TranslatorDictionary.xml. Does not do that if the xml does not exist.